### PR TITLE
fix error "certificate signed by unknown authority"

### DIFF
--- a/src/test/bash/env.sh
+++ b/src/test/bash/env.sh
@@ -2,4 +2,4 @@
 
 export VAULT_ADDR="https://localhost:8200"
 export VAULT_TOKEN=00000000-0000-0000-0000-000000000000
-export VAULT_CAPATH="$(pwd)/work/ca/certs/ca.cert.pem"
+export VAULT_CACERT="$(pwd)/work/ca/certs/ca.cert.pem"


### PR DESCRIPTION
* VAULT_CAPATH's value is a cert file not "the full path to a directory containing certificates including that of the relevant CA" (https://support.hashicorp.com/hc/en-us/articles/8107320508947-x509-certificate-signed-by-unknown-authority-) changing to VAULT_CACERT solved the error "certificate signed by unknown authority"